### PR TITLE
cmd dispatcher: increase bitmaps to accommodate all IDs

### DIFF
--- a/phl/phl_cmd_dispatcher.c
+++ b/phl/phl_cmd_dispatcher.c
@@ -23,7 +23,7 @@
 #endif
 
 #define MAX_CMD_REQ_NUM (8)
-#define MODL_MASK_LEN (PHL_BK_MDL_END/8)
+#define MODL_MASK_LEN DIV_ROUND_UP(PHL_MDL_ID_MAX, 8)
 
 #define GEN_VALID_HDL(_idx) ((u32)(BIT31 | (u32)(_idx)))
 #define IS_HDL_VALID(_hdl) ((_hdl) & BIT31)


### PR DESCRIPTION
The bitmaps were sized by the BK module size, yet accessed up to the foreground module.  Size them to accommodate up to PHL_MDL_ID_MAX

Signed-off-by: Greg Whiteley <greg.whiteley@gmail.com>