### PR TITLE
Update readme to point to supported drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# rtw8852be
+# This driver is deprecated. For a supported driver, see https://github.com/lwfinger/rtw89
+
 Linux driver for RTW8852BE PCIe card
 
 ---


### PR DESCRIPTION
This is still the first repo that comes up when you google "8852be linux drivers", so I figured it would help reduce confusion to point to the supported driver.